### PR TITLE
Update SVP, Data & AI title copy across pages

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -5,11 +5,11 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <!-- The above 3 meta tags *must* come first in the head; any other head content must come *after* these tags -->
-    <meta name="description" content="">
+    <meta name="description" content="Sam Edelstein, SVP, Data & AI.">
     <meta name="author" content="">
     <link rel="icon" href="../../favicon.ico">
 
-    <title>Sam Edelstein</title>
+    <title>Sam Edelstein | SVP, Data & AI</title>
 
     <!-- Bootstrap core CSS -->
     <link href="/css/bootstrap.min.css" rel="stylesheet">

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -5,11 +5,11 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <!-- The above 3 meta tags *must* come first in the head; any other head content must come *after* these tags -->
-    <meta name="description" content="">
+    <meta name="description" content="Sam Edelstein, SVP, Data & AI.">
     <meta name="author" content="">
     <link rel="icon" href="../../favicon.ico">
 
-    <title>Sam Edelstein</title>
+    <title>Sam Edelstein | SVP, Data & AI</title>
 
     <!-- Bootstrap core CSS -->
     <link href="/css/bootstrap.min.css" rel="stylesheet">

--- a/about.html
+++ b/about.html
@@ -36,7 +36,7 @@ title: about
       <div class="text">
         <h1>About me</h1>
         <img src="img/samandada.jpg" align="left">
-        <p class="lead">Hi! I'm Sam Edelstein. I am Vice President of Data and Analytics at Insight Partners where I manage the analytics and the data governance teams, made up of data analysts, analytics engineers, data engineers, and data scientists. In this work, we build out the data platforms and data products to increase the value of data for the rest of the organization.
+        <p class="lead">Hi! I'm Sam Edelstein. I am Senior Vice President, Data & AI at Insight Partners where I manage the analytics and the data governance teams, made up of data analysts, analytics engineers, data engineers, and data scientists. In this work, we build out the data platforms and data products to increase the value of data for the rest of the organization.
         <br>
         <br> Previously, I served as the City of Syracuse's first Chief Data Officer. During my time as CDO, some of the most exciting projects were launching the City of Syracuse's first open data portal, <a href="http://data.syr.gov">DataCuse</a>, and working with Data Science for Social Good to build a predictive model to assess water main risk.
         <br>

--- a/index.html
+++ b/index.html
@@ -47,7 +47,7 @@ const App = () => {
 
   const experience = [
     {
-      role: "Vice President, Data & Analytics",
+      role: "Senior Vice President, Data & AI",
       company: "Insight Partners",
       period: "Present",
       description: "Leading data strategy and analytics initiatives for a premier global venture capital and private equity firm.",
@@ -155,7 +155,7 @@ const App = () => {
               Leveraging data to build <span className="text-blue-600 italic">smarter</span> organizations.
             </h1>
             <p className="text-xl text-slate-600 mb-8 leading-relaxed">
-              I am the Vice President of Data & Analytics at Insight Partners and the former Chief Data Officer for the City of Syracuse. I bridge the gap between complex data infrastructure and real-world impact.
+              I am the Senior Vice President, Data & AI at Insight Partners and the former Chief Data Officer for the City of Syracuse. I bridge the gap between complex data infrastructure and real-world impact.
             </p>
             <div className="flex flex-wrap gap-4">
               <a 

--- a/resume/index.html
+++ b/resume/index.html
@@ -29,7 +29,7 @@
   <div class='row'>
     <div class='col-md-12'>
       <h1>Sam Edelstein</h1>
-      <h4>Chief Data Officer, City of Syracuse</h4>
+      <h4>Senior Vice President, Data & AI</h4>
     </div>
   </div>
 </div>


### PR DESCRIPTION
### Motivation
- Align public-facing role copy across the site to the new title "Senior Vice President, Data & AI" for consistency. 
- Ensure shared layout metadata and page title reflect the condensed `SVP, Data & AI` phrasing for site-wide consistency and SEO.

### Description
- Updated the Insight Partners role in `index.html` (experience array) and the hero subhead to `Senior Vice President, Data & AI`.
- Updated the lead paragraph in `about.html` to use `Senior Vice President, Data & AI`.
- Replaced the resume header in `resume/index.html` from `Chief Data Officer, City of Syracuse` to `Senior Vice President, Data & AI`.
- Updated `_layouts/default.html` and `_includes/header.html` to set the meta description and `<title>` to include `SVP, Data & AI`.

### Testing
- Ran `rg` searches to verify all intended occurrences were updated and the checks passed.
- Launched a local server with `python -m http.server` and executed a Playwright script to capture a homepage screenshot, which completed successfully.
- No unit tests were applicable for this static content change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695b24e63e18832599818dba0d38c501)