### PR TITLE
Update hero copy with executive snapshot and CTA row

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,6 +6,7 @@ import {
   ExternalLink, 
   MapPin, 
   Briefcase, 
+  Mail,
   GraduationCap, 
   Award,
   ChevronRight,
@@ -147,34 +148,58 @@ const App = () => {
         </div>
       )}
 
-      <main className="max-w-5xl mx-auto px-6 pt-32 pb-20">
+      <main className="max-w-5xl mx-auto px-6 pt-24 md:pt-32 pb-20">
         {/* Hero Section */}
         <section id="home" className="mb-24 scroll-mt-32">
           <div className="max-w-3xl">
-            <h1 className="text-5xl md:text-6xl font-extrabold text-slate-900 mb-6 leading-tight">
-              Leveraging data to build <span className="text-blue-600 italic">smarter</span> organizations.
+            <h1 className="text-4xl md:text-6xl font-extrabold text-slate-900 mb-4 leading-tight">
+              Executive data &amp; AI leadership for measurable growth.
             </h1>
-            <p className="text-xl text-slate-600 mb-8 leading-relaxed">
-              I am the Senior Vice President, Data & AI at Insight Partners and the former Chief Data Officer for the City of Syracuse. I bridge the gap between complex data infrastructure and real-world impact.
+            <p className="text-lg md:text-xl text-slate-600 mb-6 leading-relaxed">
+              SVP, Data &amp; AI at Insight Partners and former Chief Data Officer for the City of Syracuse. I help organizations build trusted data foundations, deploy responsible AI, and translate insights into outcomes.
             </p>
-            <div className="flex flex-wrap gap-4">
+            <ul className="list-disc pl-5 text-slate-700 space-y-2 mb-6">
+              <li>Enterprise data strategy, AI roadmap, and operating model design.</li>
+              <li>Governed data platforms, analytics products, and MLOps execution.</li>
+              <li>Public-sector transformation and private-equity portfolio support.</li>
+              <li>Board-ready storytelling and cross-functional change leadership.</li>
+            </ul>
+            <div className="flex flex-wrap items-center gap-3">
               <a 
                 href="https://docs.google.com/document/d/e/2PACX-1vTs3WwrJMp1Lif09iYsuXadtaKJ0hhIBVpk_mdzSRtPtTmf9IhwnHtXpJsSw-ZcmxH3WlmrWrqasMCX/pub" 
                 target="_blank"
                 rel="noreferrer"
-                className="flex items-center space-x-2 bg-slate-900 text-white px-6 py-3 rounded-full hover:bg-blue-600 transition-all shadow-lg shadow-blue-200"
+                className="flex items-center space-x-2 bg-slate-900 text-white px-5 py-3 rounded-full hover:bg-blue-600 transition-all shadow-lg shadow-blue-200"
               >
                 <FileText size={18} />
-                <span>View Resume</span>
+                <span>Download Resume (PDF)</span>
               </a>
               <button 
-                onClick={() => scrollToSection('writing')}
-                className="flex items-center space-x-2 bg-white border border-slate-200 text-slate-700 px-6 py-3 rounded-full hover:border-blue-300 transition-all"
+                onClick={() => scrollToSection('contact')}
+                className="flex items-center space-x-2 bg-white border border-slate-200 text-slate-700 px-5 py-3 rounded-full hover:border-blue-300 transition-all"
               >
-                <BookOpen size={18} />
-                <span>Read Articles</span>
+                <Mail size={18} />
+                <span>Contact Me</span>
               </button>
+              <button 
+                onClick={() => scrollToSection('experience')}
+                className="flex items-center space-x-2 bg-white border border-slate-200 text-slate-700 px-5 py-3 rounded-full hover:border-blue-300 transition-all"
+              >
+                <Briefcase size={18} />
+                <span>View Case Studies</span>
+              </button>
+              <a
+                href="https://www.linkedin.com/in/samedelstein"
+                target="_blank"
+                rel="noreferrer"
+                className="text-sm font-semibold text-slate-500 hover:text-blue-600 transition-colors"
+              >
+                LinkedIn
+              </a>
             </div>
+            <p className="text-xs text-slate-400 mt-3">
+              Confidentiality respected; detailed case studies shared on request.
+            </p>
           </div>
         </section>
 
@@ -268,7 +293,7 @@ const App = () => {
               </ul>
             </section>
 
-            <section className="p-8 bg-blue-600 rounded-[2.5rem] text-white shadow-xl shadow-blue-200 relative overflow-hidden">
+            <section id="contact" className="p-8 bg-blue-600 rounded-[2.5rem] text-white shadow-xl shadow-blue-200 relative overflow-hidden scroll-mt-24">
               <div className="relative z-10">
                 <h3 className="text-2xl font-bold mb-4">Let's Connect</h3>
                 <p className="text-blue-100 mb-8 leading-relaxed">


### PR DESCRIPTION
### Motivation
- Refresh the homepage hero to foreground executive Data & AI leadership and measurable outcomes.  
- Surface an "Executive Snapshot" of key capabilities as four concise bullets for quick scannability.  
- Add a prominent CTA row in the requested order: `Download Resume (PDF)`, `Contact Me`, `View Case Studies`, and a small `LinkedIn` link.  
- Ensure CTAs and hero spacing render higher on mobile so primary actions appear above the fold and include a confidentiality micro-note below CTAs.

### Description
- Updated the React-based `index.html` hero: replaced the headline and subhead, reduced top padding on small screens (`pt-24 md:pt-32`), and added a 4-item bulleted "Executive Snapshot" list.  
- Reworked the CTA row: changed the resume button label to `Download Resume (PDF)`, added `Contact Me` (imports `Mail` icon and scrolls to `#contact`), added a `View Case Studies` button which scrolls to `#experience`, and added a small `LinkedIn` link with updated styling.  
- Added a confidentiality micro-note below the CTAs and added `id=

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695b27494d7883258aca455de7e8f081)