### PR TITLE
Add mailto-based “Contact Me” buttons to header and hero

### DIFF
--- a/index.html
+++ b/index.html
@@ -113,6 +113,13 @@ const App = () => {
           </div>
 
           <div className="flex items-center space-x-4">
+            <a
+              href="mailto:sam.i.edelstein@gmail.com?subject=Recruiter%20inquiry%20—%20SVP%20Data%20%26%20AI&body=Role:%0ACompany:%0ATiming:%0ARemote%20/%20Hybrid:%0AComp:%0A%0AAdditional%20details:%0A"
+              className="hidden md:inline-flex items-center space-x-2 bg-slate-900 text-white px-4 py-2 rounded-full text-sm font-semibold hover:bg-blue-600 transition-all shadow-lg shadow-blue-200"
+            >
+              <Mail size={16} />
+              <span>Contact Me</span>
+            </a>
              <a href="https://www.linkedin.com/in/samedelstein" target="_blank" rel="noreferrer" className="text-slate-400 hover:text-blue-600 transition-colors">
                <Linkedin size={20} />
              </a>
@@ -174,13 +181,13 @@ const App = () => {
                 <FileText size={18} />
                 <span>Download Resume (PDF)</span>
               </a>
-              <button 
-                onClick={() => scrollToSection('contact')}
+              <a
+                href="mailto:sam.i.edelstein@gmail.com?subject=Recruiter%20inquiry%20—%20SVP%20Data%20%26%20AI&body=Role:%0ACompany:%0ATiming:%0ARemote%20/%20Hybrid:%0AComp:%0A%0AAdditional%20details:%0A"
                 className="flex items-center space-x-2 bg-white border border-slate-200 text-slate-700 px-5 py-3 rounded-full hover:border-blue-300 transition-all"
               >
                 <Mail size={18} />
                 <span>Contact Me</span>
-              </button>
+              </a>
               <button 
                 onClick={() => scrollToSection('experience')}
                 className="flex items-center space-x-2 bg-white border border-slate-200 text-slate-700 px-5 py-3 rounded-full hover:border-blue-300 transition-all"


### PR DESCRIPTION
### Motivation
- Provide a direct recruiter contact flow from the site without rendering the email address as visible text. 
- Surface a prominent call-to-action in the sticky header and hero to make outreach easier for recruiters and partners. 

### Description
- Added a desktop header `mailto:` button (hidden on small screens) that opens a prefilled email template. 
- Replaced the hero's scroll-to-contact button with an inline `mailto:` link using the same prefilled template. 
- Changes were made in `index.html` and keep the email address out of visible page text by only embedding it in the `href` values. 

### Testing
- Started a local static server with `python -m http.server 8000` and it served the site successfully. 
- Captured a full-page screenshot using a Playwright script against `index.html`, which completed successfully. 
- No unit or integration test suite was run for this static UI change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695b2cc3a2588325a0b2081b0b684ebf)